### PR TITLE
fix: suppress dotenv warnings in all scripts

### DIFF
--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -16,7 +16,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 function checkEnvironmentVariables(): void {
-  config({ path: join(process.cwd(), '.env.local') });
+  config({ path: join(process.cwd(), '.env.local'), quiet: true });
 
   const envExamplePath = join(process.cwd(), '.env.example');
 

--- a/tests/setup/integration.ts
+++ b/tests/setup/integration.ts
@@ -1,7 +1,7 @@
 import { config } from 'dotenv';
 import { join } from 'path';
 
-config({ path: join(process.cwd(), '.env.local') });
+config({ path: join(process.cwd(), '.env.local'), quiet: true });
 
 process.env.RATE_LIMIT_REQUESTS = '5';
 process.env.RATE_LIMIT_WINDOW = '10 m';


### PR DESCRIPTION
## Summary
• Apply `quiet: true` option to all dotenv config calls to eliminate warning messages
• Fixes dotenv warnings in both integration test setup and build scripts
• Consistent approach across all environment loading

## Test plan
- [x] Integration tests run without dotenv warning messages
- [x] Build scripts run without dotenv warning messages
- [x] All existing functionality remains unchanged