### PR TITLE
EMB-1708: fix manual email test assertion for Result<T,E> shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,9 @@
         "vitest": "^3.2.4",
         "webpack-bundle-analyzer": "^4.10.2"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@tailwindcss/oxide-linux-x64-gnu": "^4.1.11",
         "lightningcss-linux-x64-gnu": "^1.30.1"

--- a/src/features/contact/EmailService.manual.test.ts
+++ b/src/features/contact/EmailService.manual.test.ts
@@ -39,10 +39,10 @@ describe('Resend Email Integration (Manual)', () => {
     const result = await emailService.sendContactEmail(testData);
 
     expect(result).toMatchObject({
+      success: true,
       data: {
         id: expect.stringMatching(/^(?!mock-email-id$).+/)
-      },
-      error: null
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

The manual email integration test `src/features/contact/EmailService.manual.test.ts` was asserting against the old Resend-style `{ data, error: null }` return shape. After `EmailService.sendContactEmail` was refactored to return a `Result<T, E>` discriminated union (`{ success: true, data }` on success, `{ success: false, error }` on failure), the assertion was never updated, so the weekly `Weekly Boundary Tests` workflow started failing even though the email was sending successfully.

This PR updates the assertion to match the success variant of `Result<T, E>`. No production code changes.

[EMB-1708](https://linear.app/ember-and-tide/issue/EMB-1708/bug-emailservicemanualtestts-assertion-out-of-sync-with-resultte)

## Changes

- `src/features/contact/EmailService.manual.test.ts` — assert `{ success: true, data: { id } }` instead of `{ data: { id }, error: null }`
- `package-lock.json` — sync `engines.node` field injected by `npm install` (unrelated housekeeping, kept as its own commit)

## Special Notes

- The manual test runs only via `npm run test:manual` (separate `vitest.manual.config.mts`). It is not part of the default unit/integration/e2e suites or any pre-commit hook.
- The only thing that actually exercises it is `.github/workflows/weekly-boundary-tests.yml` (added Friday in EMB-1661 / 62208d9) — that workflow's first real run is what surfaced the stale assertion.
- Verified locally: `npm run test:manual` now passes against a real Resend send (live email received at the configured recipient).
- No extra unit test was added to cover the `Result.success` shape — that would test an implementation detail already enforced by the `Result<T, E>` discriminated union in `src/shared/Result.ts`. The manual test is the boundary test for this path.

## Testing

- [ ] CI: `Weekly Boundary Tests` workflow passes on next scheduled run (or via manual `workflow_dispatch`)
- [x] Manual: with valid `RESEND_API_KEY`, `FROM_EMAIL` (on a verified Resend domain), `TO_EMAIL`, and `SEND_EMAIL_ENABLED=true` configured locally, `npm run test:manual` passes and a live email is received
- Automated coverage: unit and integration suites continue to pass; assertion change is verified end-to-end by the manual test itself